### PR TITLE
Feat/tweet table

### DIFF
--- a/db/migrations/003_create_tweets_down.sql
+++ b/db/migrations/003_create_tweets_down.sql
@@ -1,0 +1,2 @@
+DROP TABLE tweets;
+DROP EXTENSION IF EXISTS "pgcrypto";

--- a/db/migrations/003_create_tweets_up.sql
+++ b/db/migrations/003_create_tweets_up.sql
@@ -1,0 +1,12 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE tweets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL
+);
+
+ALTER TABLE tweets ADD CONSTRAINT fk_tweets_users FOREIGN KEY (user_id) REFERENCES users(id);

--- a/models/tweet.go
+++ b/models/tweet.go
@@ -1,0 +1,16 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Tweet struct {
+	ID        uuid.UUID `gorm:"type:uuid;primaryKey"`
+	UserID    uuid.UUID `gorm:"not null"`
+	Content   string    `gorm:"not null"`
+	CreatedAt time.Time `gorm:"not null;default CURRENT_TIMESTAMP;column:created_at"`
+	UpdatedAt time.Time `gorm:"not null;default CURRENT_TIMESTAMP;column:updated_at"`
+	DeletedAt *time.Time `gorm:"column:deleted_at"` //nilを許可
+}


### PR DESCRIPTION
Tweets モデルとマイグレーションの追加
## 概要
- Tweet モデルを追加し、ユーザーとの紐付けとソフトデリート対応のフィールドを定義
- tweets テーブル作成用マイグレーションを追加し、UUID 主キーと users テーブルへの外部キー制約を設定
- ロールバック用に tweets テーブルと pgcrypto 拡張を削除するダウンマイグレーションを用意
## 確認方法
- goose postgres <DSN> up（または既存のマイグレーションコマンド）を実行し、マイグレーションが正常に適用されることを確認
- goose postgres <DSN> down を実行し、ロールバックがエラーなく完了することを確認